### PR TITLE
Improve Query Perforamance

### DIFF
--- a/flatfs.go
+++ b/flatfs.go
@@ -325,15 +325,22 @@ func (fs *Datastore) walkTopLevel(path string, reschan chan query.Result) error 
 	if err != nil {
 		return err
 	}
+	defer dir.Close()
 	names, err := dir.Readdirnames(-1)
 	if err != nil {
 		return err
 	}
 	for _, dir := range names {
+
+		if len(dir) == 0 || dir[0] == '.' {
+			continue
+		}
+
 		err = fs.walk(filepath.Join(path, dir), reschan)
 		if err != nil {
 			return err
 		}
+
 	}
 	return nil
 }
@@ -343,6 +350,7 @@ func (fs *Datastore) walk(path string, reschan chan query.Result) error {
 	if err != nil {
 		return err
 	}
+	defer dir.Close()
 	names, err := dir.Readdirnames(-1)
 	if err != nil {
 		return err


### PR DESCRIPTION
filepath.Walk() sorts the names and calls lstat() on each entry, both of which are unnecessary when all we need are the key names in random order.

Instead I just use the fact that the directory layout is fixed and just use Readdirnames.

With a sample datastore with 100000 small keys the speedup is around 2.2:
```
100000 ORIG 3443.543417 (+/- 63.378649) ms
100000 OPT 1558.430242 (+/- 28.740522) ms
```
When there are only 10000 keys the speedup is around 1.3:
```
10000 ORIG 199.053565 (+/- 12.956540) ms
10000 OPT 151.882705 (+/- 8.869852) ms
```
