### PR TITLE
Ignore non-directories in the top level directory.

### DIFF
--- a/flatfs.go
+++ b/flatfs.go
@@ -357,6 +357,16 @@ func (fs *Datastore) walk(path string, reschan chan query.Result) error {
 		return err
 	}
 	defer dir.Close()
+
+	// ignore non-directories
+	fileInfo, err := dir.Stat()
+	if err != nil {
+		return err
+	}
+	if !fileInfo.IsDir() {
+		return nil
+	}
+
 	names, err := dir.Readdirnames(-1)
 	if err != nil {
 		return err

--- a/flatfs.go
+++ b/flatfs.go
@@ -320,7 +320,7 @@ func (fs *Datastore) Query(q query.Query) (query.Results, error) {
 		defer close(reschan)
 		err := fs.walkTopLevel(fs.path, reschan)
 		if err != nil {
-			log.Warning("walk failed: ", err)
+			reschan <- query.Result{Error: errors.New("walk failed: " + err.Error())}
 		}
 	}()
 	return query.ResultsWithChan(q, reschan), nil

--- a/flatfs_test.go
+++ b/flatfs_test.go
@@ -343,6 +343,11 @@ func testQuerySimple(dirFunc mkShardFunc, t *testing.T) {
 	temp, cleanup := tempdir(t)
 	defer cleanup()
 
+	err := ioutil.WriteFile(filepath.Join(temp, "README"), []byte("something"), 0666)
+	if err != nil {
+		t.Fatalf("WriteFile fail: %v\n", err)
+	}
+
 	fs, err := flatfs.New(temp, dirFunc(2), false)
 	if err != nil {
 		t.Fatalf("New fail: %v\n", err)


### PR DESCRIPTION
Ignore non-directories in the top level directory to allow placing a README or similar file there.

This is based on #6.

