### PR TITLE
Change go-os-rename to standard

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
-	"github.com/jbenet/go-os-rename"
 )
 
 func UpgradeV0toV1(path string, prefixLen int) error {
@@ -152,7 +151,7 @@ func Move(oldPath string, newPath string, out io.Writer) error {
 			// else we found something unexpected, so to be safe just move it
 			log.Warningf("found unexpected file in datastore directory: \"%s\", moving anyway\n", fn)
 			newPath := filepath.Join(newDS.path, fn)
-			err := osrename.Rename(oldPath, newPath)
+			err := os.Rename(oldPath, newPath)
 			if err != nil {
 				return err
 			}
@@ -173,7 +172,7 @@ func moveKey(oldDS *Datastore, newDS *Datastore, key datastore.Key) error {
 	if err != nil {
 		return err
 	}
-	err = osrename.Rename(oldPath, newPath)
+	err = os.Rename(oldPath, newPath)
 	if err != nil {
 		return err
 	}

--- a/flatfs.go
+++ b/flatfs.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
-	"github.com/jbenet/go-os-rename"
 
 	logging "github.com/ipfs/go-log"
 )
@@ -286,7 +285,7 @@ func (fs *Datastore) renameAndUpdateDiskUsage(tmpPath, path string) error {
 	// Rename and add new file's diskUsage. If the rename fails,
 	// it will either a) Re-add the size of an existing file, which
 	// was sustracted before b) Add 0 if there is no existing file.
-	err = osrename.Rename(tmpPath, path)
+	err = os.Rename(tmpPath, path)
 	fs.updateDiskUsage(path, true)
 	return err
 }
@@ -779,7 +778,7 @@ func (fs *Datastore) persistDiskUsageFile() {
 		return
 	}
 
-	osrename.Rename(tmp.Name(), filepath.Join(fs.path, DiskUsageFile))
+	os.Rename(tmp.Name(), filepath.Join(fs.path, DiskUsageFile))
 }
 
 func (fs *Datastore) readDiskUsageFile() int64 {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,6 @@
     },
     {
       "author": "jbenet",
-      "hash": "QmaeRR9SpXumU5tYLRkq6x6pfMe8qKzxn4ujBpsTJ2zQG7",
-      "name": "go-os-rename",
-      "version": "0.0.0"
-    },
-    {
-      "author": "jbenet",
       "hash": "QmeiCcJfDW1GJnWUArudsv5rQsihpi4oyddPhdqo3CfX6i",
       "name": "go-datastore",
       "version": "2.4.1"


### PR DESCRIPTION
Since Go 1.5, os.Rename on Windows is consistent with other platforms. `go-os-rename` just enforced consistent behaviour on Windows before the change was made upstream, for other platforms it used the standard. Since both are the same now it seems redundant to keep it.