### PR TITLE
check error before defer-removing disk usage file

### DIFF
--- a/flatfs.go
+++ b/flatfs.go
@@ -863,6 +863,11 @@ func (fs *Datastore) checkpointLoop() {
 
 func (fs *Datastore) writeDiskUsageFile(du int64, doSync bool) {
 	tmp, err := ioutil.TempFile(fs.path, "du-")
+	if err != nil {
+		log.Warningf("cound not write disk usage: %v", err)
+		return
+	}
+
 	removed := false
 	defer func() {
 		if !removed {
@@ -870,10 +875,6 @@ func (fs *Datastore) writeDiskUsageFile(du int64, doSync bool) {
 			_ = os.Remove(tmp.Name())
 		}
 	}()
-	if err != nil {
-		log.Warningf("cound not write disk usage: %v", err)
-		return
-	}
 
 	toWrite := fs.storedValue
 	toWrite.DiskUsage = du


### PR DESCRIPTION
Ran into this while updating our gx deps:
https://circleci.com/gh/qri-io/cafs/43

Not being able to write the temp file in the first place is the source of the failure, but handling errors before invoking defer statements on nil pointers is a good idea IMHO 😉