### PR TITLE
feat: put all temporary files in the same directory and clean them up

### DIFF
--- a/flatfs_test.go
+++ b/flatfs_test.go
@@ -187,7 +187,7 @@ func testStorage(p *params, t *testing.T) {
 			return err
 		}
 		switch path {
-		case ".", "..", "SHARDING", flatfs.DiskUsageFile:
+		case ".", "..", "SHARDING", flatfs.DiskUsageFile, ".temp":
 			// ignore
 		case "_README":
 			_, err := ioutil.ReadFile(absPath)
@@ -950,9 +950,8 @@ func TestNoCluster(t *testing.T) {
 	tolerance := math.Floor(idealFilesPerDir * 0.25)
 	count := 0
 	for _, dir := range dirs {
-		if dir.Name() == flatfs.SHARDING_FN ||
-			dir.Name() == flatfs.README_FN ||
-			dir.Name() == flatfs.DiskUsageFile {
+		switch dir.Name() {
+		case flatfs.SHARDING_FN, flatfs.README_FN, flatfs.DiskUsageFile, ".temp":
 			continue
 		}
 		count += 1


### PR DESCRIPTION
Otherwise, if we repeatedly stop the same node, we'll collect a bunch of temporary files and NEVER DELETE them. This will:

1. Waste space.
2. Slow down queries/GC.

This patch:

1. Moves all temporary files to a single `.temp` directory. The leading `.` means it can't conflict with any keys and queries (even on older flatfs versions) will skip it.
2. Adds an "rm -rf flatfs-dir/.temp" call on start.