### PR TITLE
Add NewDatastore entry point

### DIFF
--- a/flatfs.go
+++ b/flatfs.go
@@ -297,6 +297,11 @@ func CreateOrOpen(path string, fun *ShardIdV1, sync bool) (*Datastore, error) {
 	return Open(path, sync)
 }
 
+// NewDatastore is a common interface to go-datastore for opening with default options.
+func NewDatastore(path string, options *interface{}) (*Datastore, error) {
+	return CreateOrOpen(path, IPFS_DEF_SHARD, false)
+}
+
 func (fs *Datastore) ShardStr() string {
 	return fs.shardStr
 }


### PR DESCRIPTION
the fuzzer defaults to instantiating datastore implementations using `NewDatastore`, and interface method present in most of the other datastore implementations. Proposing adding here for ease of fuzzing.