### PR TITLE
wire a context in most of the Datastore methods

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -4,6 +4,7 @@
 package flatfs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -59,7 +60,7 @@ func Move(oldPath string, newPath string, out io.Writer) error {
 	}
 	newDS.deactivate()
 
-	res, err := oldDS.Query(query.Query{KeysOnly: true})
+	res, err := oldDS.Query(context.TODO(), query.Query{KeysOnly: true})
 	if err != nil {
 		return err
 	}

--- a/flatfs.go
+++ b/flatfs.go
@@ -4,6 +4,7 @@
 package flatfs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -393,7 +394,7 @@ func (fs *Datastore) renameAndUpdateDiskUsage(tmpPath, path string) error {
 // one arrived slightly later than the other. In the case of a
 // concurrent Put and a Delete operation, we cannot guarantee which one
 // will win.
-func (fs *Datastore) Put(key datastore.Key, value []byte) error {
+func (fs *Datastore) Put(ctx context.Context, key datastore.Key, value []byte) error {
 	if !keyIsValid(key) {
 		return fmt.Errorf("when putting '%q': %v", key, ErrInvalidKey)
 	}
@@ -412,7 +413,7 @@ func (fs *Datastore) Put(key datastore.Key, value []byte) error {
 	return err
 }
 
-func (fs *Datastore) Sync(prefix datastore.Key) error {
+func (fs *Datastore) Sync(ctx context.Context, prefix datastore.Key) error {
 	fs.shutdownLock.RLock()
 	defer fs.shutdownLock.RUnlock()
 	if fs.shutdown {
@@ -644,7 +645,7 @@ func (fs *Datastore) putMany(data map[datastore.Key][]byte) error {
 	return nil
 }
 
-func (fs *Datastore) Get(key datastore.Key) (value []byte, err error) {
+func (fs *Datastore) Get(ctx context.Context, key datastore.Key) (value []byte, err error) {
 	// Can't exist in datastore.
 	if !keyIsValid(key) {
 		return nil, datastore.ErrNotFound
@@ -662,7 +663,7 @@ func (fs *Datastore) Get(key datastore.Key) (value []byte, err error) {
 	return data, nil
 }
 
-func (fs *Datastore) Has(key datastore.Key) (exists bool, err error) {
+func (fs *Datastore) Has(ctx context.Context, key datastore.Key) (exists bool, err error) {
 	// Can't exist in datastore.
 	if !keyIsValid(key) {
 		return false, nil
@@ -679,7 +680,7 @@ func (fs *Datastore) Has(key datastore.Key) (exists bool, err error) {
 	}
 }
 
-func (fs *Datastore) GetSize(key datastore.Key) (size int, err error) {
+func (fs *Datastore) GetSize(ctx context.Context, key datastore.Key) (size int, err error) {
 	// Can't exist in datastore.
 	if !keyIsValid(key) {
 		return -1, datastore.ErrNotFound
@@ -699,7 +700,7 @@ func (fs *Datastore) GetSize(key datastore.Key) (size int, err error) {
 // Delete removes a key/value from the Datastore. Please read
 // the Put() explanation about the handling of concurrent write
 // operations to the same key.
-func (fs *Datastore) Delete(key datastore.Key) error {
+func (fs *Datastore) Delete(ctx context.Context, key datastore.Key) error {
 	// Can't exist in datastore.
 	if !keyIsValid(key) {
 		return nil
@@ -744,7 +745,7 @@ func (fs *Datastore) doDelete(key datastore.Key) error {
 	return err
 }
 
-func (fs *Datastore) Query(q query.Query) (query.Results, error) {
+func (fs *Datastore) Query(ctx context.Context, q query.Query) (query.Results, error) {
 	prefix := datastore.NewKey(q.Prefix).String()
 	if prefix != "/" {
 		// This datastore can't include keys with multiple components.
@@ -1211,7 +1212,7 @@ func (fs *Datastore) Batch() (datastore.Batch, error) {
 	}, nil
 }
 
-func (bt *flatfsBatch) Put(key datastore.Key, val []byte) error {
+func (bt *flatfsBatch) Put(ctx context.Context, key datastore.Key, val []byte) error {
 	if !keyIsValid(key) {
 		return fmt.Errorf("when putting '%q': %v", key, ErrInvalidKey)
 	}
@@ -1219,20 +1220,20 @@ func (bt *flatfsBatch) Put(key datastore.Key, val []byte) error {
 	return nil
 }
 
-func (bt *flatfsBatch) Delete(key datastore.Key) error {
+func (bt *flatfsBatch) Delete(ctx context.Context, key datastore.Key) error {
 	if keyIsValid(key) {
 		bt.deletes[key] = struct{}{}
 	} // otherwise, delete is a no-op anyways.
 	return nil
 }
 
-func (bt *flatfsBatch) Commit() error {
+func (bt *flatfsBatch) Commit(ctx context.Context) error {
 	if err := bt.ds.putMany(bt.puts); err != nil {
 		return err
 	}
 
 	for k := range bt.deletes {
-		if err := bt.ds.Delete(k); err != nil {
+		if err := bt.ds.Delete(ctx, k); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Master issue: https://github.com/ipfs/go-ipfs/issues/6803

This only do the wiring. Actual usage for cancellation, logging or tracing is
left for a future work.