### PR TITLE
fix: actually use the size hint in util_windows.go

### DIFF
--- a/util_windows.go
+++ b/util_windows.go
@@ -12,7 +12,7 @@ package flatfs
 
 import (
 	"bytes"
-	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -83,19 +83,23 @@ func readFileOnce(filename string) ([]byte, error) {
 	defer f.Close()
 	// It's a good but not certain bet that FileInfo will tell us exactly how much to
 	// read, so let's try it but be prepared for the answer to be wrong.
-	var n int64 = bytes.MinRead
+	var sizeHint int = bytes.MinRead
 
 	if fi, err := f.Stat(); err == nil {
-		// As initial capacity for readAll, use Size + a little extra in case Size
-		// is zero, and to avoid another allocation after Read has filled the
-		// buffer. The readAll call will read into its allocated internal buffer
-		// cheaply. If the size was wrong, we'll either waste some space off the end
-		// or reallocate as needed, but in the overwhelmingly common case we'll get
-		// it just right.
-		if size := fi.Size() + bytes.MinRead; size > n {
-			n = size
+		if sz := fi.Size(); sz <= math.MaxInt {
+			if sz := int(sz); sz > sizeHint {
+				sizeHint = sz
+			}
 		}
+		sizeHint++ // one byte for final read at EOF
 	}
 
-	return io.ReadAll(f)
+	var buf bytes.Buffer
+	buf.Grow(sizeHint)
+	_, err = buf.ReadFrom(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
This code was broken, it computed the size hint to do nothing with it.

Found with this profile:
![Capture d’écran du 2022-08-02 15-40-33](https://user-images.githubusercontent.com/24391983/182390557-6682d6d1-398e-4dd1-a4dd-6e02f7fbbd30.png)

This profile clearly show a pattern of `append`'s growth.
With this new code the only way to `append` is if the size hint undershoot (which would require more data to be written between the `Size` and `Read` calls). Might be worth a `panic("race")` or returning an error if that happen ?

