### PR TITLE
fix: use 0666 for temp files so umask controls final permissions

### DIFF
--- a/util_unix.go
+++ b/util_unix.go
@@ -7,7 +7,17 @@ import (
 )
 
 func tempFileOnce(dir, pattern string) (*os.File, error) {
-	return os.CreateTemp(dir, pattern)
+	f, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return nil, err
+	}
+	// os.CreateTemp hardcodes 0600; relax to 0666 so umask controls final permissions
+	if err := f.Chmod(0666); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return nil, err
+	}
+	return f, nil
 }
 
 func readFileOnce(filename string) ([]byte, error) {

--- a/util_windows.go
+++ b/util_windows.go
@@ -61,7 +61,7 @@ func tempFileOnce(dir, pattern string) (f *os.File, err error) {
 	nconflict := 0
 	for i := 0; i < 10000; i++ {
 		name := filepath.Join(dir, prefix+nextRandom()+suffix)
-		f, err = goissue34681.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+		f, err = goissue34681.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 		if os.IsExist(err) {
 			if nconflict++; nconflict > 10 {
 				randmu.Lock()


### PR DESCRIPTION
## Summary

- `os.CreateTemp` hardcodes mode `0600`, so renamed block files inherit `0600` regardless of the process umask. This prevents other users/processes from reading the blockstore even with correct group membership and a permissive umask (e.g. `0022`).
- Chmod temp files to `0666` after creation (unix) and create with `0666` (windows) so the **umask** controls final permissions — consistent with the batch path which already uses `os.Create` / `OpenFile` with `0666`.

## Changes

- **`util_unix.go`**: After `os.CreateTemp`, `Chmod(0666)` so umask applies. Cleans up on error.
- **`util_windows.go`**: Change `OpenFile` mode from `0600` → `0666` for consistency.

## Test plan

- [x] Verify existing tests pass (`go test ./...`)
- [ ] Manual: write a block via `ipfs add`, confirm file permissions match expected umask (e.g. `0644` with umask `0022`)