### PR TITLE
fix: make last batch operation take effect

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -344,6 +344,135 @@ func testBatchDiscard(dirFunc mkShardFunc, t *testing.T) {
 	}
 }
 
+func TestBatchPutDeleteSameKey(t *testing.T) {
+	temp := t.TempDir()
+	ctx := t.Context()
+
+	ffs, err := flatfs.CreateOrOpen(temp, flatfs.Prefix(2), false)
+	if err != nil {
+		t.Fatalf("New fail: %v\n", err)
+	}
+	defer ffs.Close()
+
+	// Put some initial data in the datastore
+	keyA := datastore.NewKey("KEYA")
+	dataA := []byte("dataA")
+	err = ffs.Put(ctx, keyA, dataA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyB := datastore.NewKey("KEYB")
+	dataB := []byte("dataB")
+	err = ffs.Put(ctx, keyB, dataB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a batch
+	batch, err := ffs.Batch(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that last operation wins: Delete, Put
+	err = batch.Delete(ctx, keyA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	overwriteA := []byte("data-A-overwrite")
+	err = batch.Put(ctx, keyA, overwriteA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that last operation wins: Put, Delete
+	overwriteB := []byte("data-B-overwrite")
+	err = batch.Put(ctx, keyB, overwriteB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = batch.Delete(ctx, keyB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that last operation wins: Put, Delete, Put
+	keyX := datastore.NewKey("KEYX")
+	dataX1 := []byte("data-X-1")
+	err = batch.Put(ctx, keyX, dataX1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = batch.Delete(ctx, keyX)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataX2 := []byte("data-X-2")
+	err = batch.Put(ctx, keyX, dataX2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that last operation wins: Put, Delete, Put, Delete
+	keyY := datastore.NewKey("KEYY")
+	dataY1 := []byte("data-Y-1")
+	err = batch.Put(ctx, keyX, dataY1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = batch.Delete(ctx, keyY)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = batch.Put(ctx, keyY, dataY1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = batch.Delete(ctx, keyY)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit the batch
+	err = batch.Commit(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify final state in main datastore.
+
+	// keyA should exist and be overwritten.
+	data, err := ffs.Get(ctx, keyA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(overwriteA) {
+		t.Errorf("expected %s, got %s", overwriteA, data)
+	}
+
+	// keyB should be deleted.
+	_, err = ffs.Get(ctx, keyB)
+	if err != datastore.ErrNotFound {
+		t.Errorf("expected ErrNotFound for deleted keyB after commit, got %v", err)
+	}
+
+	// keyX should be added with initial value.
+	data, err = ffs.Get(ctx, keyX)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(dataX1) {
+		t.Errorf("expected %s, got %s", dataX1, data)
+	}
+
+	// keyY should not exist
+	_, err = ffs.Get(ctx, keyY)
+	if err != datastore.ErrNotFound {
+		t.Errorf("expected ErrNotFound for keyY after commit, got %v", err)
+	}
+}
+
 func TestBatchQuery(t *testing.T) {
 	tryAllShardFuncs(t, testBatchQuery)
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -417,7 +417,7 @@ func TestBatchPutDeleteSameKey(t *testing.T) {
 	// Check that last operation wins: Put, Delete, Put, Delete
 	keyY := datastore.NewKey("KEYY")
 	dataY1 := []byte("data-Y-1")
-	err = batch.Put(ctx, keyX, dataY1)
+	err = batch.Put(ctx, keyY, dataY1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/flatfs.go
+++ b/flatfs.go
@@ -1139,6 +1139,10 @@ type BatchReader interface {
 // for content-addressed storage where identical keys guarantee identical values.
 // For mutable data requiring last-writer-wins, use a different datastore.
 //
+// [Put] and [Delete] for same key:
+//   - Delete after Put: [Commit] removes Put and deletes item from datastore.
+//   - Put after Delete: Put removes Delete from batch and adds Put.
+//
 // Concurrency: Safe for concurrent calls to Put/Delete/Get/Has/GetSize/Query.
 // Not safe to call Commit or Discard concurrently with other operations.
 //
@@ -1227,6 +1231,9 @@ func (bt *flatfsBatch) Put(ctx context.Context, key datastore.Key, val []byte) e
 	}
 
 	bt.mu.Lock()
+
+	// Cancel any previous delete operation in this batch.
+	delete(bt.deletes, key)
 
 	// Skip duplicate keys to prevent concurrent goroutines from writing to the
 	// same temp file. Without this check, two Put calls with the same key
@@ -1614,6 +1621,9 @@ func (bt *flatfsBatch) Commit(ctx context.Context) error {
 
 	// First, ensure all destination directories exist
 	for _, key := range bt.puts {
+		if _, deleted := bt.deletes[key]; deleted {
+			continue
+		}
 		dir, _ := bt.ds.encode(key)
 		if _, err := bt.ds.makeDirNoSync(dir); err != nil {
 			return fmt.Errorf("failed to create directory: %w", err)
@@ -1623,6 +1633,9 @@ func (bt *flatfsBatch) Commit(ctx context.Context) error {
 
 	// Move all temp files to their final destinations
 	for _, key := range bt.puts {
+		if _, deleted := bt.deletes[key]; deleted {
+			continue
+		}
 		noslash := key.String()[1:]
 		fileName := noslash + extension
 		tempFile := filepath.Join(bt.tempDir, fileName)


### PR DESCRIPTION
When adding Put and Delete operations to a batch, for the same key, make the last operation be the one to take effect.

Put and Delete for same key:
- Delete after Put: Commit removes Put and deletes item from datastore.
- Put after Delete: Put removes Delete from batch and adds Put.

Closes #49